### PR TITLE
Features: copy text to Clipboard; move Submit button to top

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -224,11 +224,10 @@ function render_response(response_data) {
     let copy_to_clipboard_total = document.getElementById('copy-to-clipboard-total');
     let total_text = response_data['total'].toString();
     copy_to_clipboard_total.addEventListener('click', function () {
-        writeToClipboard(total_text, (error, result) => {
+        writeToClipboard(total_text, (error) => {
             if (error) {
-              console.error('Error:', error);
+              window.prompt("Copy to clipboard: Ctrl+C, Enter", response_text);
             } else {
-              console.log('Result:', result);
               const backup = copy_to_clipboard_total.innerHTML;
               copy_to_clipboard_total.innerHTML = "Copied!"
               setTimeout(() => {

--- a/popup.js
+++ b/popup.js
@@ -273,24 +273,3 @@ function writeToClipboard(textToCopy, callback) {
         }
       });
   }
-
-function copyToClipboardOld(text) {
-    if (window.clipboardData && window.clipboardData.setData) {
-        // IE specific code path to prevent textarea being shown while dialog is visible.
-        return clipboardData.setData("Text", text); 
-  
-    } else if (document.queryCommandSupported && document.queryCommandSupported("copy")) {
-        var textarea = document.createElement("textarea");
-        textarea.textContent = text;
-        textarea.style.position = "fixed";  // Prevent scrolling to bottom of page in MS Edge.
-        document.body.appendChild(textarea);
-        textarea.select();
-        try {
-            return document.execCommand("copy");  // Security exception may be thrown by some browsers.
-        } catch (ex) {
-            return false;
-        } finally {
-            document.body.removeChild(textarea);
-        }
-    }
-  }

--- a/popup.js
+++ b/popup.js
@@ -207,11 +207,10 @@ function render_response(response_data) {
     let response_text = htmlDecode(response_data['trade_message']);
     let copy_to_clipboard = document.getElementById('copy-to-clipboard');
     copy_to_clipboard.addEventListener('click', function () {
-        writeToClipboard(response_text, (error, result) => {
+        writeToClipboard(response_text, (error) => {
             if (error) {
-              console.error('Error:', error);
+                window.prompt("Copy to clipboard: Ctrl+C, Enter", response_text);
             } else {
-              console.log('Result:', result);
               const backup = copy_to_clipboard.innerHTML;
               copy_to_clipboard.innerHTML = "Copied!"
               setTimeout(() => {

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -48,28 +48,33 @@ chrome.runtime.onMessage.addListener((msg, sender, response) => {
         
         const regex_splitter = /\sx(?=\d{1,10})/
         let trade_elements = document.querySelectorAll("#trade-container > div.trade-cont.m-top10 > div.user.right > ul > li > ul > li > div.name.left")
-        console.log(trade_elements);
+        // console.log(trade_elements);
         for (let i=0; i<trade_elements.length; i++){
 
             // if string is not  '' or ' '
             if ((trade_elements[i].textContent) && (trade_elements[i].textContent.trim() !== ''))  {
                
                 let textContent = trade_elements[i].textContent.split(regex_splitter);
-                console.log(textContent);
                 
                 if (textContent.length == 2){
                     items.push(sanitizeItemName(textContent[0]));
                     quantities.push(parseInt(sanitizeItemName(textContent[1])));
                 }
                 else if (textContent.length == 1){
-                    items.push(sanitizeItemName(textContent[0]));
+                    const sanitized = sanitizeItemName(textContent[0]);
+                    if (sanitized == "No items in trade") {
+                        alert("No items in trade or trade already finished.");
+                        throw new Error("No items in trade or trade already finished.");
+                    }
+
+                    items.push(sanitized);
                     quantities.push(1);
                 }
             }
         }
 
         responseData = getPricesFromPlayerApi(items, quantities, sellerName, userName);
-        console.log(responseData);
+        // console.log(responseData);
         var domInfo = {
             buyer_name: responseData.buyer_name,
             image_url: responseData.image_url,

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -48,7 +48,7 @@ chrome.runtime.onMessage.addListener((msg, sender, response) => {
         
         const regex_splitter = /\sx(?=\d{1,10})/
         let trade_elements = document.querySelectorAll("#trade-container > div.trade-cont.m-top10 > div.user.right > ul > li > ul > li > div.name.left")
-        // console.log(trade_elements);
+
         for (let i=0; i<trade_elements.length; i++){
 
             // if string is not  '' or ' '
@@ -74,7 +74,7 @@ chrome.runtime.onMessage.addListener((msg, sender, response) => {
         }
 
         responseData = getPricesFromPlayerApi(items, quantities, sellerName, userName);
-        // console.log(responseData);
+        
         var domInfo = {
             buyer_name: responseData.buyer_name,
             image_url: responseData.image_url,

--- a/tornexchange-extension.css
+++ b/tornexchange-extension.css
@@ -140,22 +140,9 @@ td.profit {
     float: right;
 }
 
-.copy-text a:link {
-    text-decoration: none;
-    color: inherit;
-}
-
-.copy-text a:visited {
-    text-decoration: none;
-    color: inherit;
-}
-
-.copy-text a:hover {
-    text-decoration: none;
-    color: inherit;
-}
-
+.copy-text a:link,
+.copy-text a:visited,
+.copy-text a:hover,
 .copy-text a:active {
     text-decoration: none;
-    color: inherit;
 }

--- a/tornexchange-extension.css
+++ b/tornexchange-extension.css
@@ -139,3 +139,23 @@ td.profit {
     border-radius: 0px;
     float: right;
 }
+
+.copy-text a:link {
+    text-decoration: none;
+    color: inherit;
+}
+
+.copy-text a:visited {
+    text-decoration: none;
+    color: inherit;
+}
+
+.copy-text a:hover {
+    text-decoration: none;
+    color: inherit;
+}
+
+.copy-text a:active {
+    text-decoration: none;
+    color: inherit;
+}


### PR DESCRIPTION
**Feature 1**
Until now, user (usually a trader) was presented with default JS prompt and had to CTRL+C to copy the total money amount. This update makes use of new `navigator.clipboard` functionality to copy the content directly to user's Clipboard.

UI gives a temporary visual confirmation of copied text and then reverts back to original text. Example of new icon with hover text as well:
![image](https://github.com/torn-exchange/extension/assets/155850761/75b926a5-048a-459b-aa67-74b9850326c1)

Copied total amount:
![image](https://github.com/torn-exchange/extension/assets/155850761/3dbc3fdc-71d2-47a2-aaae-14d4c9c4aa0c)

Copied receipt template:
![image](https://github.com/torn-exchange/extension/assets/155850761/9a6791fa-9611-4dff-a1f7-ad7a199bd6d9)

**Feature 2**
When there's too many different items in the trade, popup would become sticky (non-scrollable) on mobile. That means the Submit button would be hidden, thus preventing going to second screen to copy trade amount as well as non-generation of a receipt. This PR fixes it by simply prepending the submit HTML to the top, instead of appending it.

**Feature 3**
When the extension is clicked on a trade that has been already finished, or there are no items in a trade yet, it now triggers an alert instead of producing an error.